### PR TITLE
Update file naming scheme to fit standard and add annual ball to the navbar

### DIFF
--- a/_content/fukseille/mika-on-fuksi/mika-on-fuksi.en.md
+++ b/_content/fukseille/mika-on-fuksi/mika-on-fuksi.en.md
@@ -1,0 +1,9 @@
+---
+title: What is a fresher?
+---
+
+## What is a fresher?
+
+Fresher refers to first year engineering students. It is called *fuksi* in Finnish and *gulis* in Swedish.
+Teekkarifreshers will receive their overalls but no teekkari caps yet. They are filling in fresher's passes during the
+first academic year and attend Eldprowet in order to receive teekkari caps.

--- a/_content/fukseille/mika-on-fuksi/mika-on-fuksi.fi.md
+++ b/_content/fukseille/mika-on-fuksi/mika-on-fuksi.fi.md
@@ -1,0 +1,10 @@
+---
+title: Mikä on fuksi?
+---
+
+## Mikä on fuksi?
+
+Fuksi tarkoittaa ensimmäisen vuoden opiskelijaa. Teekkarit käyttävät nimitystä teekkarifuksi, mutta muilla aloilla
+saatetaan käyttää myös muita nimityksiä, kuten piltti tai fetus. Teekkarifuksit saavat haalarinsa jo ensimmäisen syksyn
+aikana, mutta ei vielä teekkarilakkeja. Lakin saamiseksi fuksien tulee suorittaa ensimmäisen opiskeluvuotensa aikana
+fuksipassin ja osallistuvat Eldprowetiin.

--- a/_content/fukseille/mika-on-fuksi/mika-on-fuksi.sv.md
+++ b/_content/fukseille/mika-on-fuksi/mika-on-fuksi.sv.md
@@ -1,0 +1,9 @@
+---
+title: Vad är en gulis?
+---
+
+## Vad är en gulis?
+
+Gulis eller gulnäbb betyder första årets studerande. Teknologgulisar får sina halare redan under den första hösten men
+inte ännu teknologmössor. För att få sina mössor ska gulisar fylla i gulispass under det första studieåret och delta i
+Eldprowet.

--- a/_content/fukseille/mikä-on-fuksi/mikä-on-fuksi.en.md
+++ b/_content/fukseille/mikä-on-fuksi/mikä-on-fuksi.en.md
@@ -1,7 +1,0 @@
----
-title: What is a fresher?
----
-## What is a fresher?
-
-
-Fresher refers to first year engineering students. It is called *fuksi* in Finnish and *gulis* in Swedish. Teekkarifreshers will receive their overalls but no teekkari caps yet. They are filling in fresher's passes during the first academic year and attend Eldprowet in order to receive teekkari caps.

--- a/_content/fukseille/mikä-on-fuksi/mikä-on-fuksi.fi.md
+++ b/_content/fukseille/mikä-on-fuksi/mikä-on-fuksi.fi.md
@@ -1,7 +1,0 @@
----
-title: Mikä on fuksi?
----
-## Mikä on fuksi?
-
-
-Fuksi tarkoittaa ensimmäisen vuoden opiskelijaa. Teekkarit käyttävät nimitystä teekkarifuksi, mutta muilla aloilla saatetaan käyttää myös muita nimityksiä, kuten piltti tai fetus. Teekkarifuksit saavat haalarinsa jo ensimmäisen syksyn aikana, mutta ei vielä teekkarilakkeja. Lakin saamiseksi fuksien tulee suorittaa ensimmäisen opiskeluvuotensa aikana fuksipassin ja osallistuvat Eldprowetiin.

--- a/_content/fukseille/mikä-on-fuksi/mikä-on-fuksi.sv.md
+++ b/_content/fukseille/mikä-on-fuksi/mikä-on-fuksi.sv.md
@@ -1,8 +1,0 @@
----
-title: Vad är en gulis?
----
-## Vad är en gulis?
-
-
-
-Gulis eller gulnäbb betyder första årets studerande. Teknologgulisar får sina halare redan under den första hösten men inte ännu teknologmössor. För att få sina mössor ska gulisar fylla i gulispass under det första studieåret och delta i Eldprowet.

--- a/_content/tapahtumat/jaynagaala/jaynagaala.en.md
+++ b/_content/tapahtumat/jaynagaala/jaynagaala.en.md
@@ -1,0 +1,10 @@
+---
+title: Jäynä Gala
+---
+
+## Jäynä Gala
+
+The local jäynä competition of Turku reaches climax in the Jäynä Gala, where all of the jäynä documentations are watched
+together. The practical jokes are reviewed and given credit or criticism. In the event, Teekkarikomissio announces the
+winners of each series in the competition (open, fresher and guild series) and the winners are awarded. Even shame
+diplomas will be given to guilds that have not attended the guild series in given time.

--- a/_content/tapahtumat/jaynagaala/jaynagaala.fi.md
+++ b/_content/tapahtumat/jaynagaala/jaynagaala.fi.md
@@ -1,0 +1,11 @@
+---
+title: Jäynägaala
+---
+
+## Jäynägaala
+
+Turun paikalliset jäynäkilpailut huipentuvat Jäynägaalaan, missä palkitaan Teekkarikomission toimesta jäynäsarjojen
+voittajat. Jäynägaala järjestetään yleensä aina osana Teekkariwappua aivan huhtikuun lopulla, 28.4. Gaalassa katsotaan
+kaikki jäynät läpi yleisön kanssa, mikä on parhaimmillaan ratkiriemukasta. Gaalassa tuomarit kommentoivat jäynien hyviä
+ja huonoja puolia sekä lopulta antavat tuomionsa jäynien sijoituksista. Gaalassa jaetaan myös häpeädiplomit kaikille
+niille killoille, jotka eivät ole palauttaneet jäynää kiltasarjaan kisa-ajan puitteissa.

--- a/_content/tapahtumat/jaynagaala/jaynagaala.sv.md
+++ b/_content/tapahtumat/jaynagaala/jaynagaala.sv.md
@@ -1,0 +1,10 @@
+---
+title: Jäynägala
+---
+
+## Jäynägala
+
+Åbos lokala jäynätävlingar kulminerar i Jäynägala var vinnare av jäynäserier belönas av Teknologkommissionen. Jäynägala
+arrangeras ofta som en del av Teekkariwappu helt i slutet av april, den 28.4. Alla jäynör ska tittas på tillsammans med
+publiken vilket är uppsluppet. Domare kommenterar, ger återkoppling och poängsätter inlämnade jäynös till sist. Även
+skamdiplom ska delas ut till ämnesföreningar som inte har lämnat in en jäynä i föreningsserie på utsatt tid.

--- a/_content/tapahtumat/jaynastartti/jaynastartti.en.md
+++ b/_content/tapahtumat/jaynastartti/jaynastartti.en.md
@@ -1,0 +1,10 @@
+---
+title: Jäynä Start
+---
+
+## Jäynä Start
+
+In Jäynä Start, Teekkarikomissio announces the opening of the Jäynä Competition, liberally translated to “practical joke
+competition”. The Jäynä Competition goes on from the Jäynästart to the end of March or the beginning of April.
+Jäynästart consists of going through the rules of the competition, and reminds what is a good Jäynä. To give rise to
+inspiration, practical jokes from the past are watched together. The different series will also be announced.

--- a/_content/tapahtumat/jaynastartti/jaynastartti.fi.md
+++ b/_content/tapahtumat/jaynastartti/jaynastartti.fi.md
@@ -1,0 +1,10 @@
+---
+title: Jäynästartti
+---
+
+## Jäynästartti
+
+Jäynäkilpailut avataan Jäynästärtissa, jossa Teekkarikomissio kertoo jäynäämisestä ja sen säännöistä. Kilpailut kestävät
+Jäynästartista maalis-huhtikuun vaihteeseen, jolloin jäynä tulee viimeistään palauttaa. Jäynästartissa näytetään
+esimerkkejä menneisyydessä toteutetuista jäynistä. Näistä voi saada hyvää inspiraatiota itse jäynään, jäynän kohteeseen
+tai dokumentointiin liittyen. Startissa kerrotaan myös eri sarjat, joihin voi osallistua.

--- a/_content/tapahtumat/jaynastartti/jaynastartti.sv.md
+++ b/_content/tapahtumat/jaynastartti/jaynastartti.sv.md
@@ -1,0 +1,10 @@
+---
+title: Jäynästart
+---
+
+## Jäynästart
+
+Jäynätävlingarna öppnas i Jäynästarten där Teknologkommissionen berättar om utförandet av jäynä och dess regler.
+Jäynätävlingen håller på från Jäynästarten till månadsskiftet mars-april när jäynän ska senast lämnas in. I Jäynästarten
+visas tidigare jäynör som kan ge inspiration till själva jäynän, dess föremål eller dokumentation. Olika serier, som man
+kan delta i, ska också representeras.

--- a/_content/tapahtumat/jäynägaala/jäynägaala.en.md
+++ b/_content/tapahtumat/jäynägaala/jäynägaala.en.md
@@ -1,6 +1,0 @@
----
-title: Jäynä Gala
----
-## Jäynä Gala
-
-The local jäynä competition of Turku reaches climax in the Jäynä Gala, where all of the jäynä documentations are watched together. The practical jokes are reviewed and given credit or criticism. In the event, Teekkarikomissio announces the winners of each series in the competition (open, fresher and guild series) and the winners are awarded. Even shame diplomas will be given to guilds that have not attended the guild series in given time.

--- a/_content/tapahtumat/jäynägaala/jäynägaala.fi.md
+++ b/_content/tapahtumat/jäynägaala/jäynägaala.fi.md
@@ -1,6 +1,0 @@
----
-title: Jäynägaala
----
-## Jäynägaala
-
-Turun paikalliset jäynäkilpailut huipentuvat Jäynägaalaan, missä palkitaan Teekkarikomission toimesta jäynäsarjojen voittajat. Jäynägaala järjestetään yleensä aina osana Teekkariwappua aivan huhtikuun lopulla, 28.4. Gaalassa katsotaan kaikki jäynät läpi yleisön kanssa, mikä on parhaimmillaan ratkiriemukasta. Gaalassa tuomarit kommentoivat jäynien hyviä ja huonoja puolia sekä lopulta antavat tuomionsa jäynien sijoituksista. Gaalassa jaetaan myös häpeädiplomit kaikille niille killoille, jotka eivät ole palauttaneet jäynää kiltasarjaan kisa-ajan puitteissa.

--- a/_content/tapahtumat/jäynägaala/jäynägaala.sv.md
+++ b/_content/tapahtumat/jäynägaala/jäynägaala.sv.md
@@ -1,6 +1,0 @@
----
-title: Jäynägala
----
-## Jäynägala
-
-Åbos lokala jäynätävlingar kulminerar i Jäynägala var vinnare av jäynäserier belönas av Teknologkommissionen. Jäynägala arrangeras ofta som en del av Teekkariwappu helt i slutet av april, den 28.4. Alla jäynör ska tittas på tillsammans med publiken vilket är uppsluppet. Domare kommenterar, ger återkoppling och poängsätter inlämnade jäynös till sist. Även skamdiplom ska delas ut till ämnesföreningar som inte har lämnat in en jäynä i föreningsserie på utsatt tid.

--- a/_content/tapahtumat/jäynästartti/jäynästartti.en.md
+++ b/_content/tapahtumat/jäynästartti/jäynästartti.en.md
@@ -1,6 +1,0 @@
----
-title: Jäynä Start
----
-## Jäynä Start
-
-In Jäynä Start, Teekkarikomissio announces the opening of the Jäynä Competition, liberally translated to “practical joke competition”. The Jäynä Competition goes on from the Jäynästart to the end of March or the beginning of April. Jäynästart consists of going through the rules of the competition, and reminds what is a good Jäynä. To give rise to inspiration, practical jokes from the past are watched together. The different series will also be announced.

--- a/_content/tapahtumat/jäynästartti/jäynästartti.fi.md
+++ b/_content/tapahtumat/jäynästartti/jäynästartti.fi.md
@@ -1,6 +1,0 @@
----
-title: Jäynästartti
----
-## Jäynästartti
-
-Jäynäkilpailut avataan Jäynästärtissa, jossa Teekkarikomissio kertoo jäynäämisestä ja sen säännöistä. Kilpailut kestävät Jäynästartista maalis-huhtikuun vaihteeseen, jolloin jäynä tulee viimeistään palauttaa. Jäynästartissa näytetään esimerkkejä menneisyydessä toteutetuista jäynistä. Näistä voi saada hyvää inspiraatiota itse jäynään, jäynän kohteeseen tai dokumentointiin liittyen. Startissa kerrotaan myös eri sarjat, joihin voi osallistua.

--- a/_content/tapahtumat/jäynästartti/jäynästartti.sv.md
+++ b/_content/tapahtumat/jäynästartti/jäynästartti.sv.md
@@ -1,6 +1,0 @@
----
-title: Jäynästart
----
-## Jäynästart
-
-Jäynätävlingarna öppnas i Jäynästarten där Teknologkommissionen berättar om utförandet av jäynä och dess regler. Jäynätävlingen håller på från Jäynästarten till månadsskiftet mars-april när jäynän ska senast lämnas in. I Jäynästarten visas tidigare jäynör som kan ge inspiration till själva jäynän, dess föremål eller dokumentation. Olika serier, som man kan delta i, ska också representeras.

--- a/_content/tapahtumat/sommartraff/sommartraff.en.md
+++ b/_content/tapahtumat/sommartraff/sommartraff.en.md
@@ -1,0 +1,8 @@
+---
+title: Sommarträff
+---
+
+## Sommarträff
+
+Sommarträff is a relaxed and free hanging event where other teekkari students can be met during summer. There is no
+fixed time or format but it has often been a picnic or barbecue in June or July.

--- a/_content/tapahtumat/sommartraff/sommartraff.fi.md
+++ b/_content/tapahtumat/sommartraff/sommartraff.fi.md
@@ -1,0 +1,9 @@
+---
+title: Sommarträff
+---
+
+## Sommarträff
+
+Sommarträff on kesäisin järjestettävä matalan kynnyksen maksuton hengailutapatuma, jossa voi päästä tapaamaan muita
+teekkareita kesän aikana. Sommarträffillä ei ole vakituista ajankohtaa tai formaattia, mutta se on useimmiten
+kesä-heinäkuussa järjestetty piknik- tai grillitapahtuma.

--- a/_content/tapahtumat/sommartraff/sommartraff.sv.md
+++ b/_content/tapahtumat/sommartraff/sommartraff.sv.md
@@ -1,0 +1,8 @@
+---
+title: Sommarträff
+---
+
+## Sommarträff
+
+Sommarträff är ett gratis och avslappnat evenemang med låg tröskel där man kan träffa andra teknologer under sommaren.
+Sommarträff har inget fastspikad tidpunkt eller format men oftast är det en piknik eller ett grillevenemang i juni-juli.

--- a/_content/tapahtumat/sommarträff/sommarträff.en.md
+++ b/_content/tapahtumat/sommarträff/sommarträff.en.md
@@ -1,6 +1,0 @@
----
-title: Sommarträff
----
-## Sommarträff
-
-Sommarträff is a relaxed and free hanging event where other teekkari students can be met during summer. There is no fixed time or format but it has often been a picnic or barbecue in June or July.

--- a/_content/tapahtumat/sommarträff/sommarträff.fi.md
+++ b/_content/tapahtumat/sommarträff/sommarträff.fi.md
@@ -1,6 +1,0 @@
----
-title: Sommarträff
----
-## Sommarträff
-
-Sommarträff on kesäisin järjestettävä matalan kynnyksen maksuton hengailutapatuma, jossa voi päästä tapaamaan muita teekkareita kesän aikana. Sommarträffillä ei ole vakituista ajankohtaa tai formaattia, mutta se on useimmiten kesä-heinäkuussa järjestetty piknik- tai grillitapahtuma.

--- a/_content/tapahtumat/sommarträff/sommarträff.sv.md
+++ b/_content/tapahtumat/sommarträff/sommarträff.sv.md
@@ -1,6 +1,0 @@
----
-title: Sommarträff
----
-## Sommarträff
-
-Sommarträff är ett gratis och avslappnat evenemang med låg tröskel där man kan träffa andra teknologer under sommaren. Sommarträff har inget fastspikad tidpunkt eller format men oftast är det en piknik eller ett grillevenemang i juni-juli.

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -92,14 +92,14 @@ export default function Navbar({ lang, contentFolders }: NavigationBarProps) {
                       return (
                         <div
                           className={cn(
-                            "w-[400px] bg-white rounded-md border border-primary/20 ring-1 ring-primary/10 shadow-lg",
-                            many && "max-h-96 overflow-y-auto pr-2"
+                            'w-[400px] bg-white rounded-md border border-primary/20 ring-1 ring-primary/10 shadow-lg',
+                            many && 'max-h-96 overflow-y-auto pr-2'
                           )}
-                          style={{ scrollbarGutter: many ? "stable" : undefined }}
+                          style={{
+                            scrollbarGutter: many ? 'stable' : undefined,
+                          }}
                         >
-                          <ul className="grid gap-3 p-4">
-                            {listItems}
-                          </ul>
+                          <ul className="grid gap-3 p-4">{listItems}</ul>
                         </div>
                       )
                     })()}
@@ -110,11 +110,23 @@ export default function Navbar({ lang, contentFolders }: NavigationBarProps) {
                   asChild
                   className="inline-flex h-9 w-max items-center justify-center rounded-md bg-tk-blue px-4 py-2 text-sm font-medium text-white hover:bg-tk-red transition-colors"
                 >
-                  <Link href={section.href}>
-                    {section.meta.translatedTitle?.[lang] ||
-                      section.meta.title ||
-                      section.slug}
-                  </Link>
+                  {section.href.startsWith('http') ? (
+                    <a
+                      href={section.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {section.meta.translatedTitle?.[lang] ||
+                        section.meta.title ||
+                        section.slug}
+                    </a>
+                  ) : (
+                    <Link href={section.href}>
+                      {section.meta.translatedTitle?.[lang] ||
+                        section.meta.title ||
+                        section.slug}
+                    </Link>
+                  )}
                 </NavigationMenuLink>
               )}
             </NavigationMenuItem>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,14 +1,35 @@
-import matter from 'gray-matter';
-import path from 'path';
-import fs from 'fs';
+import matter from 'gray-matter'
+import path from 'path'
+import fs from 'fs'
 import { type Locale } from '@/i18n-config'
-import { notFound } from 'next/navigation';
+import { notFound } from 'next/navigation'
 
 interface NavigationItem {
   title: string;
   path: string;
   items: NavigationItem[];
 }
+
+interface SubPage {
+  href: string
+  slug: string
+  parentSlug: string
+  meta: any
+  content: string
+}
+
+interface ContentFolder {
+  href: string
+  slug: string
+  meta: {
+    title: string
+    translatedTitle: any
+    [key: string]: any
+  }
+  content: string
+  subPages: SubPage[]
+}
+
 
 export default function getPageBySlug(pageName: string, locale: Locale) {
   const pagesDirectory = path.join(process.cwd(), '_content');
@@ -64,18 +85,18 @@ export function getFolderContents(folderPath: string, locale: Locale) {
   }
 }
 
-export function getNavigationByLocale(locale: Locale) {
-  const contentDirectory = path.join(process.cwd(), "_content");
+export function getNavigationByLocale(locale: Locale): ContentFolder[] {
+  const contentDirectory = path.join(process.cwd(), '_content')
   const sections = [
     'yhdistys',
     'fukseille',
     'kulttuuri',
     'tapahtumat',
     'yhteistyo',
-    'ongelmatilannelomake'
-  ];
-  
-  try {    
+    'ongelmatilannelomake',
+  ]
+
+  try {
     const pages = sections
       .map((section) => {
         const sectionPath = path.join(contentDirectory, section)
@@ -102,7 +123,7 @@ export function getNavigationByLocale(locale: Locale) {
 
         // Get subfolders and their contents
         const contents = fs.readdirSync(sectionPath)
-        const subPages = contents
+        const subPages: SubPage[] = contents
           .filter((item) => {
             const fullPath = path.join(sectionPath, item)
             return fs.statSync(fullPath).isDirectory()
@@ -135,7 +156,7 @@ export function getNavigationByLocale(locale: Locale) {
               return null
             }
           })
-          .filter(Boolean)
+          .filter((item): item is SubPage => item !== null)
 
         return mainContent || subPages.length > 0
           ? {
@@ -154,10 +175,10 @@ export function getNavigationByLocale(locale: Locale) {
             }
           : null
       })
-      .filter(Boolean)
+      .filter((item): item is ContentFolder => item !== null)
 
     // Append external Annual Ball XXV link as a top-level nav item (temporary)
-    const annualBallItem = {
+    const annualBallItem: ContentFolder = {
       href: 'https://digit.fi/ilmo/teekkarikomissioyhdistys-ry-n-25-vuosijuhla',
       slug: 'annual-ball-xxv',
       meta: {
@@ -169,13 +190,13 @@ export function getNavigationByLocale(locale: Locale) {
         },
       },
       content: '',
-      subPages: [] as any[],
+      subPages: [],
     }
 
-    return [...(pages as any[]), annualBallItem];
+    return [...pages, annualBallItem]
   } catch (error) {
-    console.error('Error in getNavigationByLocale:', error);
-    return [];
+    console.error('Error in getNavigationByLocale:', error)
+    return []
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,9 +5,9 @@ import { type Locale } from '@/i18n-config'
 import { notFound } from 'next/navigation'
 
 interface NavigationItem {
-  title: string;
-  path: string;
-  items: NavigationItem[];
+  title: string
+  path: string
+  items: NavigationItem[]
 }
 
 interface SubPage {
@@ -30,17 +30,16 @@ interface ContentFolder {
   subPages: SubPage[]
 }
 
-
 export default function getPageBySlug(pageName: string, locale: Locale) {
-  const pagesDirectory = path.join(process.cwd(), '_content');
-  const fullPath = path.join(pagesDirectory, `${pageName}.${locale}.md`);
-  
+  const pagesDirectory = path.join(process.cwd(), '_content')
+  const fullPath = path.join(pagesDirectory, `${pageName}.${locale}.md`)
+
   try {
-    const fileContents = fs.readFileSync(fullPath, 'utf8');
-    const { content, data } = matter(fileContents);
-    return { href: `/${locale}/${pageName}`, meta: data, content };
+    const fileContents = fs.readFileSync(fullPath, 'utf8')
+    const { content, data } = matter(fileContents)
+    return { href: `/${locale}/${pageName}`, meta: data, content }
   } catch (error) {
-    notFound();
+    notFound()
   }
 }
 
@@ -48,40 +47,40 @@ export function getFolderContents(folderPath: string, locale: Locale) {
   try {
     // Check if directory exists first
     if (!fs.existsSync(folderPath)) {
-      return [];
+      return []
     }
 
-    const contents = fs.readdirSync(folderPath);
+    const contents = fs.readdirSync(folderPath)
 
     return contents.reduce((acc: NavigationItem[], item: string) => {
-      const fullPath = path.join(folderPath, item);
-      const stats = fs.statSync(fullPath);
+      const fullPath = path.join(folderPath, item)
+      const stats = fs.statSync(fullPath)
 
       if (stats.isDirectory()) {
         // Handle directory
-        const subItems = getFolderContents(fullPath, locale);
+        const subItems = getFolderContents(fullPath, locale)
         if (subItems.length > 0) {
           acc.push({
             title: item,
             path: fullPath.split('_content/')[1],
-            items: subItems
-          });
+            items: subItems,
+          })
         }
       } else if (stats.isFile() && item.endsWith(`.${locale}.md`)) {
         // Handle markdown file
-        const title = path.basename(item, `.${locale}.md`);
+        const title = path.basename(item, `.${locale}.md`)
         acc.push({
           title,
           path: fullPath.split('_content/')[1].replace(`.${locale}.md`, ''),
-          items: []
-        });
+          items: [],
+        })
       }
 
-      return acc;
-    }, []);
+      return acc
+    }, [])
   } catch (error) {
-    console.error(`Error processing folder ${folderPath}:`, error);
-    return [];
+    console.error(`Error processing folder ${folderPath}:`, error)
+    return []
   }
 }
 
@@ -204,32 +203,31 @@ const sectionTranslations = {
   yhdistys: {
     en: 'Association',
     sv: 'Föreningen',
-    fi: 'Yhdistys'
+    fi: 'Yhdistys',
   },
   fukseille: {
     en: 'For Freshmen',
     sv: 'För Gulisar',
-    fi: 'Fukseille'
+    fi: 'Fukseille',
   },
   kulttuuri: {
     en: 'Culture',
     sv: 'Kultur',
-    fi: 'Kulttuuri'
+    fi: 'Kulttuuri',
   },
   tapahtumat: {
     en: 'Events',
     sv: 'Evenemang',
-    fi: 'Tapahtumat'
+    fi: 'Tapahtumat',
   },
   yhteistyo: {
     en: 'Cooperation',
     sv: 'Samarbete',
-    fi: 'Yhteistyö'
+    fi: 'Yhteistyö',
   },
   ongelmatilannelomake: {
     en: 'Problem Report Form',
     sv: 'Trakasserianmälan',
-    fi: 'Ongelmatilannelomake'
-  }
-};
-
+    fi: 'Ongelmatilannelomake',
+  },
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -78,72 +78,101 @@ export function getNavigationByLocale(locale: Locale) {
   try {    
     const pages = sections
       .map((section) => {
-        const sectionPath = path.join(contentDirectory, section);
-        
+        const sectionPath = path.join(contentDirectory, section)
+
         if (!fs.existsSync(sectionPath)) {
-          return null;
+          return null
         }
 
         // Get main content first
-        const mainContentPath = path.join(sectionPath, `${section}.${locale}.md`);
-        let mainContent;
-        
+        const mainContentPath = path.join(
+          sectionPath,
+          `${section}.${locale}.md`
+        )
+        let mainContent
+
         try {
           if (fs.existsSync(mainContentPath)) {
-            const fileContents = fs.readFileSync(mainContentPath, "utf8");
-            mainContent = matter(fileContents);
+            const fileContents = fs.readFileSync(mainContentPath, 'utf8')
+            mainContent = matter(fileContents)
           }
         } catch (error) {
-          console.error(`Error reading main content for ${section}:`, error);
+          console.error(`Error reading main content for ${section}:`, error)
         }
 
         // Get subfolders and their contents
-        const contents = fs.readdirSync(sectionPath);
+        const contents = fs.readdirSync(sectionPath)
         const subPages = contents
-          .filter(item => {
-            const fullPath = path.join(sectionPath, item);
-            return fs.statSync(fullPath).isDirectory();
+          .filter((item) => {
+            const fullPath = path.join(sectionPath, item)
+            return fs.statSync(fullPath).isDirectory()
           })
-          .map(folder => {
+          .map((folder) => {
             try {
-              const subPagePath = path.join(sectionPath, folder, `${folder}.${locale}.md`);
-              
+              const subPagePath = path.join(
+                sectionPath,
+                folder,
+                `${folder}.${locale}.md`
+              )
+
               if (!fs.existsSync(subPagePath)) {
-                return null;
+                return null
               }
-              
-              const subPageContents = fs.readFileSync(subPagePath, "utf8");
-              const { content: subContent, data: subData } = matter(subPageContents);
-              
+
+              const subPageContents = fs.readFileSync(subPagePath, 'utf8')
+              const { content: subContent, data: subData } =
+                matter(subPageContents)
+
               return {
                 href: `/${locale}/${section}/${folder}`,
                 slug: folder,
                 parentSlug: section,
                 meta: subData,
-                content: subContent
-              };
+                content: subContent,
+              }
             } catch (error) {
-              console.error(`Error reading subpage ${folder}:`, error);
-              return null;
+              console.error(`Error reading subpage ${folder}:`, error)
+              return null
             }
           })
-          .filter(Boolean);
+          .filter(Boolean)
 
-        return mainContent || subPages.length > 0 ? {
-          href: `/${locale}/${section}`,
-          slug: section,
-          meta: {
-            ...mainContent?.data || {},
-            title: section,
-            translatedTitle: sectionTranslations[section as keyof typeof sectionTranslations]
-          },
-          content: mainContent?.content || '',
-          subPages
-        } : null;
+        return mainContent || subPages.length > 0
+          ? {
+              href: `/${locale}/${section}`,
+              slug: section,
+              meta: {
+                ...(mainContent?.data || {}),
+                title: section,
+                translatedTitle:
+                  sectionTranslations[
+                    section as keyof typeof sectionTranslations
+                  ],
+              },
+              content: mainContent?.content || '',
+              subPages,
+            }
+          : null
       })
-      .filter(Boolean);
+      .filter(Boolean)
 
-    return pages;
+    // Append external Annual Ball XXV link as a top-level nav item (temporary)
+    const annualBallItem = {
+      href: 'https://digit.fi/ilmo/teekkarikomissioyhdistys-ry-n-25-vuosijuhla',
+      slug: 'annual-ball-xxv',
+      meta: {
+        title: 'Annual Ball XXV',
+        translatedTitle: {
+          fi: 'Vuosijuhlat XXV',
+          sv: 'Årsfest XXV',
+          en: 'Annual Ball XXV',
+        },
+      },
+      content: '',
+      subPages: [] as any[],
+    }
+
+    return [...(pages as any[]), annualBallItem];
   } catch (error) {
     console.error('Error in getNavigationByLocale:', error);
     return [];


### PR DESCRIPTION
This pull request reorganises and renames content files for several events and informational pages, while also adding new files and translations for English, Finnish, and Swedish. The main goal is to standardise file naming (especially for special characters and language codes), improve translation coverage, and ensure consistency across the documentation.

Also adds a navbar item for the annual ball celebrations registration form.